### PR TITLE
Added line about real number division, to return real result, not fra…

### DIFF
--- a/data.tex
+++ b/data.tex
@@ -145,6 +145,7 @@ expected behavior:
 (* 1 2 3)    |evalsto 6
 (/ 6 3)      |evalsto 2
 (/ 22 7)     |evalsto 22/7
+(/ 22.0 7.0)     |evalsto 3.14285...
 (expt 2 3)   |evalsto 8
 (expt 4 1/2) |evalsto 2.0
 }


### PR DESCRIPTION
This is something that confused me as a noob from JavaScript/Python background, although Python doesn't give you a floating point for dividing ints either.
