### PR TITLE
One minor typo, one bug

### DIFF
--- a/mulinh.tex
+++ b/mulinh.tex
@@ -64,11 +64,10 @@ class precedence list:
 \scmdribble{
 (define create-class-proc
   (lambda (direct-superclasses slots method-names method-vector)
-    (let ((class-precedence-list
-           (delete-duplicates
-            (append-map
-             (lambda (c) (vector-ref c 2))
-             direct-superclasses))))
+    (let ((class-precedence-list (append direct-superclasses (delete-duplicates
+                                   (append-map
+                                    (lambda (c) (vector-ref c 2))
+                                    direct-superclasses)))))
       (send 'make-instance standard-class
             'class-precedence-list class-precedence-list
             'slots

--- a/obj1.tex
+++ b/obj1.tex
@@ -121,7 +121,7 @@ the instance.
 \n This  binds \q{my-bike} to the instance
 
 \q{
-#(<trivial-bike-class> cromoly 18.5 alivio)
+#(<trivial-bike-class> cromoly alivio 18.5)
 }
 
 \n where \q{<trivial-bike-class>} is a Scheme datum (another


### PR DESCRIPTION
The first change emphasizes that the order of slot values in the vector representing the instances matches the order of the slots in the slot list in the class.  

The second change fixes the fact that, when creating the super class list, the direct superclass was left out of the list of superclasses.

I was going through the code on my own to learn and something didn't make sense to me, which is how I stumbled upon the problem in the multiple inheritance code. 